### PR TITLE
Add more task container variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Module is to be used with Terraform > 0.12.
 Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](https://www.linkedin.com/in/marcincuber/).
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -51,7 +55,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | cloudwatch\_log\_group\_name | CloudWatch log group name required to enabled logDriver in container definitions for ecs task. | `string` | `""` | no |
 | container\_name | Optional name for the container to be used instead of name\_prefix. | `string` | `""` | no |
 | docker\_volume\_configuration | (Optional) Used to configure a docker volume option "docker\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html | `list` | `[]` | no |
@@ -63,12 +67,16 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | repository\_credentials\_kms\_key | key id, key ARN, alias name or alias ARN of the key that encrypted the repository credentials | `string` | `"alias/aws/secretsmanager"` | no |
 | tags | A map of tags (key-value pairs) passed to resources. | `map(string)` | `{}` | no |
 | task\_container\_command | The command that is passed to the container. | `list(string)` | `[]` | no |
+| task\_container\_cpu | Amount of CPU to reserve for the container. | `number` | `null` | no |
 | task\_container\_environment | The environment variables to pass to a container. | `map(string)` | `{}` | no |
 | task\_container\_image | The image used to start a container. | `string` | n/a | yes |
+| task\_container\_memory | The hard limit (in MiB) of memory for the container. | `number` | `null` | no |
+| task\_container\_memory\_reservation | The soft limit (in MiB) of memory to reserve for the container. | `number` | `null` | no |
 | task\_container\_port | The port number on the container that is bound to the user-specified or automatically assigned host port | `number` | `0` | no |
+| task\_container\_working\_directory | The working directory to run commands inside the container. | `string` | `""` | no |
 | task\_definition\_cpu | Amount of CPU to reserve for the task. | `number` | `256` | no |
-| task\_definition\_memory | The soft limit (in MiB) of memory to reserve for the container. | `number` | `512` | no |
-| task\_health\_check | An optional healthcheck definition for the task | `object({ command = list(string), interval = number, timeout = number, retries = number, startPeriod = number })` | n/a | yes |
+| task\_definition\_memory | The soft limit (in MiB) of memory to reserve for the task. | `number` | `512` | no |
+| task\_health\_check | An optional healthcheck definition for the task | `object({ command = list(string), interval = number, timeout = number, retries = number, startPeriod = number })` | `null` | no |
 | task\_host\_port | The port number on the container instance to reserve for your container. | `number` | `0` | no |
 | volume | (Optional) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain "name", "host\_path" and "docker\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html | `list` | `[]` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,18 @@ resource "aws_ecs_task_definition" "task" {
     },
     %{~endif}
     "command": ${jsonencode(var.task_container_command)},
+    %{if var.task_container_working_directory != ""~}
+    "workingDirectory": ${var.task_container_working_directory},
+    %{~endif}
+    %{if var.task_container_memory != null~}
+    "memory": ${var.task_container_memory},
+    %{~endif}
+    %{if var.task_container_memory_reservation != null~}
+    "memoryReservation": ${var.task_container_memory_reservation},
+    %{~endif}
+    %{if var.task_container_cpu != null~}
+    "cpu": ${var.task_container_cpu},
+    %{~endif}
     "environment": ${jsonencode(local.task_environment)}
 }]
 EOF

--- a/variables.tf
+++ b/variables.tf
@@ -39,8 +39,26 @@ variable "task_definition_cpu" {
 }
 
 variable "task_definition_memory" {
-  description = "The soft limit (in MiB) of memory to reserve for the container."
+  description = "The soft limit (in MiB) of memory to reserve for the task."
   default     = 512
+  type        = number
+}
+
+variable "task_container_cpu" {
+  description = "Amount of CPU to reserve for the container."
+  default     = null
+  type        = number
+}
+
+variable "task_container_memory" {
+  description = "The hard limit (in MiB) of memory for the container."
+  default     = null
+  type        = number
+}
+
+variable "task_container_memory_reservation" {
+  description = "The soft limit (in MiB) of memory to reserve for the container."
+  default     = null
   type        = number
 }
 
@@ -48,6 +66,12 @@ variable "task_container_command" {
   description = "The command that is passed to the container."
   default     = []
   type        = list(string)
+}
+
+variable "task_container_working_directory" {
+  description = "The working directory to run commands inside the container."
+  default     = ""
+  type        = string
 }
 
 variable "task_container_environment" {


### PR DESCRIPTION
Hi! Thanks for making this module. I stumbled upon it and it's just what we were looking for.

The only thing missing was being able to pass a few more variables to the task container definition, which I've added in this PR:
- task_container_working_directory
- task_container_memory
- task_container_memory_reservation
- task_container_cpu

Let me know what you think :)
