### PR TITLE
Add support for container timeouts and volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ No requirements.
 | task\_definition\_memory | The soft limit (in MiB) of memory to reserve for the task. | `number` | `512` | no |
 | task\_health\_check | An optional healthcheck definition for the task | `object({ command = list(string), interval = number, timeout = number, retries = number, startPeriod = number })` | `null` | no |
 | task\_host\_port | The port number on the container instance to reserve for your container. | `number` | `0` | no |
+| task\_start\_timeout | Time duration (in seconds) to wait before giving up on resolving dependencies for a container. If this parameter is not specified, the default value of 3 minutes is used (fargate). | `number` | `null` | no |
+| task\_stop\_timeout | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own. The max stop timeout value is 120 seconds and if the parameter is not specified, the default value of 30 seconds is used. | `number` | `null` | no |
 | volume | (Optional) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain "name", "host\_path" and "docker\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html | `list` | `[]` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ No requirements.
 | cloudwatch\_log\_group\_name | CloudWatch log group name required to enabled logDriver in container definitions for ecs task. | `string` | `""` | no |
 | container\_name | Optional name for the container to be used instead of name\_prefix. | `string` | `""` | no |
 | create\_repository\_credentials\_iam\_policy | Set to true if you are specifying `repository_credentials` variable, it will attach IAM policy with necessary permissions to task role. | `bool` | `false` | no |
-| docker\_volume\_configuration | (Optional) Used to configure a docker volume option "docker\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html | `list` | `[]` | no |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | `bool` | `true` | no |
 | name\_prefix | A prefix used for naming resources. | `string` | n/a | yes |
 | placement\_constraints | (Optional) A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement\_constraints is 10. This is a list of maps, where each map should contain "type" and "expression" | `list` | `[]` | no |
@@ -79,9 +78,10 @@ No requirements.
 | task\_definition\_memory | The soft limit (in MiB) of memory to reserve for the task. | `number` | `512` | no |
 | task\_health\_check | An optional healthcheck definition for the task | `object({ command = list(string), interval = number, timeout = number, retries = number, startPeriod = number })` | `null` | no |
 | task\_host\_port | The port number on the container instance to reserve for your container. | `number` | `0` | no |
+| task\_mount\_points | The mount points for data volumes in your container. Each object inside the list requires "sourceVolume", "containerPath" and "readOnly". For more information see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html | `list(object({ sourceVolume = string, containerPath = string, readOnly = bool }))` | `null` | no |
 | task\_start\_timeout | Time duration (in seconds) to wait before giving up on resolving dependencies for a container. If this parameter is not specified, the default value of 3 minutes is used (fargate). | `number` | `null` | no |
 | task\_stop\_timeout | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own. The max stop timeout value is 120 seconds and if the parameter is not specified, the default value of 30 seconds is used. | `number` | `null` | no |
-| volume | (Optional) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain "name", "host\_path" and "docker\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html | `list` | `[]` | no |
+| volume | (Optional) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain "name", "host\_path", "docker\_volume\_configuration" and "efs\_volume\_configuration". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html | `list` | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Module is to be used with Terraform > 0.12.
 ## Examples
 
 * [ECS Fargate Task Definition](https://github.com/umotif-public/terraform-aws-ecs-fargate-task-definition/tree/master/examples/core)
+* [ECS Fargate Task Definition with EFS](https://github.com/umotif-public/terraform-aws-ecs-fargate-task-definition/tree/master/examples/task-efs)
 
 ## Authors
 

--- a/examples/core/main.tf
+++ b/examples/core/main.tf
@@ -2,16 +2,20 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-data "aws_kms_key" "secretsmanager_key" {
-  key_id = "alias/aws/secretsmanager"
-}
+#####
+# Optional Secret creation for task credentials
+#####
+
+# data "aws_kms_key" "secretsmanager_key" {
+#   key_id = "alias/aws/secretsmanager"
+# }
 
 
-resource "aws_secretsmanager_secret" "task_credentials" {
-  name = "task_repository_credentials"
+# resource "aws_secretsmanager_secret" "task_credentials" {
+#   name = "task_repository_credentials"
 
-  kms_key_id = data.aws_kms_key.secretsmanager_key.arn
-}
+#   kms_key_id = data.aws_kms_key.secretsmanager_key.arn
+# }
 
 #####
 # task definition
@@ -37,7 +41,10 @@ module "ecs-task-definition" {
   cloudwatch_log_group_name = "/test-cloudwatch/log-group"
   task_container_command    = ["/bin/sh -c \"echo '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p> </div></body></html>' > /usr/local/apache2/htdocs/index.html && httpd-foreground\""]
 
-  create_repository_credentials_iam_policy = true
-  repository_credentials                   = aws_secretsmanager_secret.task_credentials.arn # also set create_repository_credentials_iam_policy = true
+  task_stop_timeout = 90
+
+  ### uncomment the following lines to use private repository credentials
+  # create_repository_credentials_iam_policy = true
+  # repository_credentials                   = aws_secretsmanager_secret.task_credentials.arn # also set create_repository_credentials_iam_policy = true
 }
 

--- a/examples/task-efs/main.tf
+++ b/examples/task-efs/main.tf
@@ -1,0 +1,58 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "aws_efs_file_system" "efs" {
+  creation_token = "efs-html"
+
+  tags = {
+    Name = "efs-html"
+  }
+}
+
+#####
+# task definition
+#####
+module "ecs-task-definition" {
+  source = "../.."
+
+  enabled              = true
+  name_prefix          = "test-container"
+  task_container_image = "httpd:2.4"
+
+  container_name      = "test-container-name"
+  task_container_port = "80"
+  task_host_port      = "80"
+
+  task_definition_cpu    = "512"
+  task_definition_memory = "1024"
+
+  task_container_environment = {
+    "ENVIRONEMNT" = "Test"
+  }
+
+  cloudwatch_log_group_name = "/test-cloudwatch/log-group"
+  task_container_command    = ["/bin/sh -c \"echo '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p> </div></body></html>' > /usr/local/apache2/htdocs/index.html && httpd-foreground\""]
+
+  task_stop_timeout = 90
+
+  task_mount_points = [
+    {
+      "sourceVolume"  = aws_efs_file_system.efs.creation_token,
+      "containerPath" = "/usr/share/nginx/html",
+      "readOnly"      = true
+    }
+  ]
+
+  volume = [
+    {
+      name = "efs-html",
+      efs_volume_configuration = [
+        {
+          "file_system_id" : aws_efs_file_system.efs.id,
+          "root_directory" : "/usr/share/nginx"
+        }
+      ]
+    }
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,12 @@ resource "aws_ecs_task_definition" "task" {
     %{if var.task_container_cpu != null~}
     "cpu": ${var.task_container_cpu},
     %{~endif}
+    %{if var.task_start_timeout != null~}
+    "startTimeout": ${var.task_start_timeout},
+    %{~endif}
+    %{if var.task_stop_timeout != null~}
+    "stopTimeout": ${var.task_stop_timeout},
+    %{~endif}
     "environment": ${jsonencode(local.task_environment)}
 }]
 EOF

--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,9 @@ resource "aws_ecs_task_definition" "task" {
     %{if var.task_stop_timeout != null~}
     "stopTimeout": ${var.task_stop_timeout},
     %{~endif}
+    %{if var.task_mount_points != null~}
+    "mountPoints": ${jsonencode(var.task_mount_points)},
+    %{~endif}
     "environment": ${jsonencode(local.task_environment)}
 }]
 EOF
@@ -158,13 +161,21 @@ EOF
       host_path = lookup(volume.value, "host_path", null)
 
       dynamic "docker_volume_configuration" {
-        for_each = var.docker_volume_configuration
+        for_each = lookup(volume.value, "docker_volume_configuration", [])
         content {
           scope         = lookup(docker_volume_configuration.value, "scope", null)
           autoprovision = lookup(docker_volume_configuration.value, "autoprovision", null)
           driver        = lookup(docker_volume_configuration.value, "driver", null)
           driver_opts   = lookup(docker_volume_configuration.value, "driver_opts", null)
           labels        = lookup(docker_volume_configuration.value, "labels", null)
+        }
+      }
+
+      dynamic "efs_volume_configuration" {
+        for_each = lookup(volume.value, "efs_volume_configuration", [])
+        content {
+          file_system_id = lookup(efs_volume_configuration.value, "file_system_id", null)
+          root_directory = lookup(efs_volume_configuration.value, "root_directory", null)
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -139,3 +139,15 @@ variable "task_health_check" {
   description = "An optional healthcheck definition for the task"
   default     = null
 }
+
+variable "task_start_timeout" {
+  type        = number
+  description = "Time duration (in seconds) to wait before giving up on resolving dependencies for a container. If this parameter is not specified, the default value of 3 minutes is used (fargate)."
+  default     = null
+}
+
+variable "task_stop_timeout" {
+  type        = number
+  description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own. The max stop timeout value is 120 seconds and if the parameter is not specified, the default value of 30 seconds is used."
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -124,13 +124,7 @@ variable "proxy_configuration" {
 
 variable "volume" {
   type        = list
-  description = "(Optional) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain \"name\", \"host_path\" and \"docker_volume_configuration\". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html"
-  default     = []
-}
-
-variable "docker_volume_configuration" {
-  type        = list
-  description = "(Optional) Used to configure a docker volume option \"docker_volume_configuration\". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html"
+  description = "(Optional) A set of volume blocks that containers in your task may use. This is a list of maps, where each map should contain \"name\", \"host_path\", \"docker_volume_configuration\" and \"efs_volume_configuration\". Full set of options can be found at https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html"
   default     = []
 }
 
@@ -149,5 +143,11 @@ variable "task_start_timeout" {
 variable "task_stop_timeout" {
   type        = number
   description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own. The max stop timeout value is 120 seconds and if the parameter is not specified, the default value of 30 seconds is used."
+  default     = null
+}
+
+variable "task_mount_points" {
+  description = "The mount points for data volumes in your container. Each object inside the list requires \"sourceVolume\", \"containerPath\" and \"readOnly\". For more information see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html "
+  type        = list(object({ sourceVolume = string, containerPath = string, readOnly = bool }))
   default     = null
 }


### PR DESCRIPTION
# Description

1. Fix volume configuration
2. Add support for container timeouts (var.task_start_timeout and var.task_stop_timeout)
3. Add support for container mountPoints (var.task_mount_points)
4. Add example for fargate task with volume and efs mount

PR addresses similar issue:
https://github.com/umotif-public/terraform-aws-ecs-fargate/issues/15
